### PR TITLE
Prevent domain ignores from affecting unrelated domains of same string length

### DIFF
--- a/src/js/whitelist.js
+++ b/src/js/whitelist.js
@@ -47,8 +47,7 @@ function parseRules(whitelist) {
 function isWhitelistRuleMatch(rule, location) {
     let noHash = location.href;
     let containsDomain = rule => {
-        let index = location.hostname.endsWith(rule.domain);
-        if (index < 0) return false;
+        if (!location.hostname.endsWith(rule.domain)) return false;
         if (location.hostname.length === rule.domain.length) {
             return true;
         } else if (location.hostname[location.hostname.length - rule.domain.length - 1] === '.') {


### PR DESCRIPTION
As requested in, and should fix #12.  Lightly tested on Firefox 84/Linux.