### PR TITLE
i18n AMO link... take 2!

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Selectors must be simple: `.class` or `#id` is okay but `div.class` is not. The 
 
 [Chrome Store](https://chrome.google.com/webstore/detail/sticky-ducky/gklhneccajklhledmencldobkjjpnhkd)
 
-[Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/sticky-ducky/)
+[Firefox Add-ons](https://addons.mozilla.org/firefox/addon/sticky-ducky/)
 
 ## Support development
 


### PR DESCRIPTION
Yep... It's a GitHub bug.  I can see it on my end too.

GitHub adds a `newline` to the last line even though I didn't touch that line.

I'll report the issue to GitHub. Since GitHub is now owned by Microsoft, they will probably claim it's a feature, not a bug. ;)

Because the last line isn't substantially changed, and GitHub probably won't be in any rush to fix their bug, my recommendation is to accept the PR and we'll use it as a reproducible example for GitHub to stop changing unedited lines in PRs.