### PR TITLE
Fix Firefox: DataCloneError when sending window.location via sendMessage

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -80,7 +80,7 @@ async function sendMessageToServiceWorker(message, retries = 3) {
 async function refreshSettings(context = 'unknown') {
     try {
         log('Refreshing settings from context:', context);
-        const locationData = _.omit(window.location, _.isFunction);
+        const locationData = _.pick(window.location, 'href', 'hostname', 'hash');
         const response = await sendMessageToServiceWorker({
             name: 'getSettings',
             message: {location: locationData}


### PR DESCRIPTION
## Problem

The extension was breaking on Firefox. The root cause is a `DataCloneError` thrown on line 83 of `content.js`:

~~~js
const locationData = _.omit(window.location, _.isFunction);
~~~

`window.location` includes `ancestorOrigins` — a `DOMStringList` — which Firefox's structured clone algorithm (used by `sendMessage` to serialize payloads) refuses to clone. This causes the initial `getSettings` message to fail silently, so `stickyFixer` is never created and no headers are hidden.

Chrome handles `DOMStringList` silently; Firefox throws a `DataCloneError`.

## Fix

Replace with `_.pick` of only the three properties that `matchWhitelist` actually reads:

~~~js
const locationData = _.pick(window.location, 'href', 'hostname', 'hash');
~~~

`matchWhitelist` only uses `href` (exact and address-part matching), `hostname` (domain matching), and `hash` (stripped before exact matching) — so no behaviour changes.

## Testing

- Firefox 150: sticky headers now hidden
- Chrome 147: no regression

---

Full disclosure: I used Claude Code to find and fix the issue